### PR TITLE
Added shaper function to the lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This can be used to transform whole arrays of objects:
 
 ```js
 // create a function with the first parameter fixed
-const userShaper = shapify.bind(null, { text: 'fullname', value: 'id' })
+const userShaper = shapify.shaper({ text: 'fullname', value: 'id' })
 
 // generate the new array
 const userChoices = users.map(userShaper)

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ const reshapedUser = shapify(
 This can be used to transform whole arrays of objects:
 
 ```js
+import { shapify, shaper } from 'shapify'
 // create a function with the first parameter fixed
-const userShaper = shapify.shaper({ text: 'fullname', value: 'id' })
+const userShaper = shaper({ text: 'fullname', value: 'id' })
 
 // generate the new array
 const userChoices = users.map(userShaper)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ exports.shapify = (mapper, obj) => {
   return res
 }
 
+exports.shaper = mapper => exports.shapify.bind(null, mapper)
+
 exports.keepKeys = obj => {
   const res = {}
   for (const key in obj) {

--- a/index.spec.js
+++ b/index.spec.js
@@ -35,13 +35,6 @@ describe('shapify', () => {
     const s = Symbol('s')
     expect(shapify({ [s]: ({ n }) => n * 2 }, { n: 3 })).toEqual({ [s]: 6 })
   })
-
-  it('shaper transforms array map', () => {
-    const testShaper = shaper({ c: 'a', d: 'b' })
-    expect([{ a: 'oldANewC', b: 'oldBNewD' }]
-      .map(testShaper))
-      .toEqual([{ c: 'oldANewC', d: 'oldBNewD' }])
-  })
 })
 
 describe('keepKeys', () => {
@@ -61,5 +54,14 @@ describe('keepKeys', () => {
       b: 'foo',
       other: true,
     })
+  })
+})
+
+describe('shaper', () => {
+  it('shaper maps the correct values to the new keys', () => {
+    const testShaper = shaper({ c: 'a', d: 'b' })
+    expect([{ a: 'oldANewC', b: 'oldBNewD' }]
+      .map(testShaper))
+      .toEqual([{ c: 'oldANewC', d: 'oldBNewD' }])
   })
 })

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,4 +1,4 @@
-const { shapify, keepKeys } = require('./index')
+const { shapify, shaper, keepKeys } = require('./index')
 
 describe('shapify', () => {
   it('renames properties', () => {
@@ -34,6 +34,13 @@ describe('shapify', () => {
   it('maps function from symbols too', () => {
     const s = Symbol('s')
     expect(shapify({ [s]: ({ n }) => n * 2 }, { n: 3 })).toEqual({ [s]: 6 })
+  })
+
+  it('shaper transforms array map', () => {
+    const testShaper = shaper({ c: 'a', d: 'b' })
+    expect([{ a: 'oldANewC', b: 'oldBNewD' }]
+      .map(testShaper))
+      .toEqual([{ c: 'oldANewC', d: 'oldBNewD' }])
   })
 })
 


### PR DESCRIPTION
By creating a simple wrapper around bind() it's possible to provide a clearer API.

This way there's no need for the user to pass null as the first parameter of bind nor understand why it's needed